### PR TITLE
Change the way response lengths and deltas are computed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wuntee</groupId>
   <artifactId>BurpAuthzPlugin</artifactId>
-  <version>0.0.6-SNAPSHOT</version>
+  <version>0.0.7-SNAPSHOT</version>
     <repositories>
     <repository>
       <id>javaxdelta.sourceforge.net</id>

--- a/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
+++ b/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
@@ -3,6 +3,7 @@ package com.wuntee.burp.authz;
 import burp.IBurpExtenderCallbacks;
 import burp.IHttpRequestResponse;
 import burp.IParameter;
+import burp.IResponseInfo;
 
 public class BurpApiHelper {
 	public static void sendRequestResponseToRepeater(IBurpExtenderCallbacks callback, IHttpRequestResponse req){
@@ -11,6 +12,20 @@ public class BurpApiHelper {
 	
 	public static void sendRequestResponseToIntruder(IBurpExtenderCallbacks callback, IHttpRequestResponse req){
 		callback.sendToIntruder(req.getHttpService().getHost(), req.getHttpService().getPort(), req.getHttpService().getProtocol().equalsIgnoreCase("https"), req.getRequest(), null);
+	}
+	
+	public static int getResponseBodyLength(IResponseInfo responseInfo, byte[] response) {
+		for (String header: responseInfo.getHeaders()) {
+			if (header.toLowerCase().startsWith("Content-Length:")) {
+				return Integer.parseInt(header.substring(header.indexOf(":")).trim());
+			}
+		}
+		
+		// if no content-length header returned, let's calculate it manually
+		String resp = new String(response);
+		String body = resp.substring(responseInfo.getBodyOffset());
+				
+		return body.length();
 	}
 	
 	public static String iParameterTypeToString(IParameter param){

--- a/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
+++ b/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
@@ -17,7 +17,7 @@ public class BurpApiHelper {
 	public static int getResponseBodyLength(IResponseInfo responseInfo, byte[] response) {
 		for (String header: responseInfo.getHeaders()) {
 			if (header.toLowerCase().startsWith("content-length:")) {
-				return Integer.parseInt(header.substring(header.indexOf(":")).trim());
+				return Integer.parseInt(header.substring(header.indexOf(":") + 1).trim());
 			}
 		}
 		

--- a/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
+++ b/src/main/java/com/wuntee/burp/authz/BurpApiHelper.java
@@ -16,7 +16,7 @@ public class BurpApiHelper {
 	
 	public static int getResponseBodyLength(IResponseInfo responseInfo, byte[] response) {
 		for (String header: responseInfo.getHeaders()) {
-			if (header.toLowerCase().startsWith("Content-Length:")) {
+			if (header.toLowerCase().startsWith("content-length:")) {
 				return Integer.parseInt(header.substring(header.indexOf(":")).trim());
 			}
 		}


### PR DESCRIPTION
This set of commits changes the way in which response lengths and deltas are computed. Rather than taking the length of the raw response (which includes the headers), this uses the Content-Length (or computed response body length). Also, when computing deltas, the response body is used without the headers. Some servers vary the order in which response headers are written, which may skew likeness ratios.  
